### PR TITLE
fix(uri): use fragment in generated uri

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"time"
 )
 
 type CreateOtsReq struct {
@@ -36,10 +37,10 @@ type CreateOtsRes struct {
 	ViewURL   *url.URL
 }
 
-func CreateOts(encryptedBytes []byte, expiresIn uint32) (*CreateOtsRes, error) {
+func CreateOts(encryptedBytes []byte, expiresIn time.Duration) (*CreateOtsRes, error) {
 	reqBody := &CreateOtsReq{
 		EncryptedBytes: base64.StdEncoding.EncodeToString(encryptedBytes),
-		ExpiresIn:      expiresIn, // Seconds resolution
+		ExpiresIn:      uint32(expiresIn.Seconds()),
 	}
 
 	resBody := &CreateOtsRes{}
@@ -57,7 +58,7 @@ func CreateOts(encryptedBytes []byte, expiresIn uint32) (*CreateOtsRes, error) {
 	}
 	defer res.Body.Close()
 
-	err = decodeJSON(res, &resBody)
+	err = decodeJSON(res, resBody)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -27,7 +27,7 @@ import (
 	"github.com/sniptt-official/ots/api/client"
 	"github.com/sniptt-official/ots/crypto/encrypt"
 	"github.com/spf13/cobra"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 const (
@@ -68,7 +68,7 @@ from the server upon retrieval therefore can only be viewed once.
 				return err
 			}
 
-			ots, err := client.CreateOts(encryptedBytes, uint32(expires.Seconds()))
+			ots, err := client.CreateOts(encryptedBytes, expires)
 			if err != nil {
 				return err
 			}
@@ -76,9 +76,9 @@ from the server upon retrieval therefore can only be viewed once.
 			expiresAt := time.Unix(ots.ExpiresAt, 0)
 
 			q := ots.ViewURL.Query()
-			q.Set("p", base64.URLEncoding.EncodeToString(secretKey))
 			q.Set("ref", "cli")
 			ots.ViewURL.RawQuery = q.Encode()
+			ots.ViewURL.Fragment = base64.URLEncoding.EncodeToString(secretKey)
 
 			fmt.Printf(`
 Your secret is now available on the below URL.
@@ -91,7 +91,7 @@ Please note that once retrieved, the secret will no longer
 be available for viewing. If not viewed, the secret will
 automatically expire at approximately %v.
 `,
-				ots.ViewURL,
+				ots.ViewURL.String(),
 				expiresAt.Format("2 Jan 2006 15:04:05"),
 			)
 
@@ -120,7 +120,7 @@ func getInputBytes() ([]byte, error) {
 	} else {
 		fmt.Print("Enter your secret: ")
 
-		bytes, err := terminal.ReadPassword(int(syscall.Stdin))
+		bytes, err := term.ReadPassword(int(syscall.Stdin))
 		if err != nil {
 			return nil, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.16
 require (
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
-	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 )

--- a/go.sum
+++ b/go.sum
@@ -259,7 +259,6 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -397,6 +396,7 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007 h1:gG67DSER+11cZvqIMb8S8bt0vZtiN6xWYARwirrOSfE=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
* update the generated URI to use fragment (addresses #1) - **backwards compatible** due to recent updates to the web project
* minor style changes/fixes
* use term directly as opposed to going through x/crypto/ssh