### PR TITLE
Create Zip files for Windows distributions

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,3 +9,9 @@ builds:
       - arm64
     ldflags:
         - -s -w -X github.com/sniptt-official/ots/build.Version={{.Version}}
+
+archives:
+  - format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip


### PR DESCRIPTION
Fixes #23 by creating zip files on Windows instead of .tar.gz