### PR TITLE
feat(api): support regional endpoints

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -20,6 +20,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -40,8 +41,14 @@ type CreateOtsRes struct {
 	ViewURL   *url.URL
 }
 
-func CreateOts(encryptedBytes []byte, expiresIn time.Duration) (*CreateOtsRes, error) {
+func CreateOts(encryptedBytes []byte, expiresIn time.Duration, region string) (*CreateOtsRes, error) {
 	baseUrl := viper.GetString("base_url")
+
+	reqUrl := url.URL{
+		Scheme: "https",
+		Host:   fmt.Sprintf("ots-api.%s.%s", region, baseUrl),
+		Path:   "secrets",
+	}
 
 	reqBody := &CreateOtsReq{
 		EncryptedBytes: base64.StdEncoding.EncodeToString(encryptedBytes),
@@ -58,7 +65,7 @@ func CreateOts(encryptedBytes []byte, expiresIn time.Duration) (*CreateOtsRes, e
 
 	client := &http.Client{}
 
-	req, err := http.NewRequest("POST", baseUrl, payloadBuf)
+	req, err := http.NewRequest("POST", reqUrl.String(), payloadBuf)
 	if err != nil {
 		return nil, err
 	}

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -46,7 +46,7 @@ func CreateOts(encryptedBytes []byte, expiresIn time.Duration, region string) (*
 
 	reqUrl := url.URL{
 		Scheme: "https",
-		Host:   fmt.Sprintf("ots-api.%s.%s", region, baseUrl),
+		Host:   fmt.Sprintf("api.%s.%s", region, baseUrl),
 		Path:   "secrets",
 	}
 

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -44,11 +44,6 @@ type CreateOtsRes struct {
 func CreateOts(encryptedBytes []byte, expiresIn time.Duration, region string) (*CreateOtsRes, error) {
 	baseUrl := viper.GetString("base_url")
 
-	region, err := getRegion(region)
-	if err != nil {
-		return nil, err
-	}
-
 	reqUrl := url.URL{
 		Scheme: "https",
 		Host:   fmt.Sprintf("ots.%s.%s", region, baseUrl),
@@ -63,7 +58,7 @@ func CreateOts(encryptedBytes []byte, expiresIn time.Duration, region string) (*
 	resBody := &CreateOtsRes{}
 
 	payloadBuf := new(bytes.Buffer)
-	err = json.NewEncoder(payloadBuf).Encode(reqBody)
+	err := json.NewEncoder(payloadBuf).Encode(reqBody)
 	if err != nil {
 		return nil, err
 	}
@@ -98,17 +93,6 @@ func CreateOts(encryptedBytes []byte, expiresIn time.Duration, region string) (*
 	resBody.ViewURL = u
 
 	return resBody, nil
-}
-
-func getRegion(region string) (string, error) {
-	switch region {
-	case "us":
-		return "us-east-1", nil
-	case "eu":
-		return "eu-central-1", nil
-	default:
-		return "", errors.New("invalid region")
-	}
 }
 
 func decodeJSON(res *http.Response, target interface{}) error {

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -47,7 +47,7 @@ func CreateOts(encryptedBytes []byte, expiresIn time.Duration, region string) (*
 	reqUrl := url.URL{
 		Scheme: "https",
 		Host:   fmt.Sprintf("api.%s.%s", region, baseUrl),
-		Path:   "secrets",
+		Path:   "one-time-secrets",
 	}
 
 	reqBody := &CreateOtsReq{

--- a/build/build.go
+++ b/build/build.go
@@ -16,5 +16,5 @@ limitations under the License.
 package build
 
 // Will be changed at build time via -ldflags
-var Version = "debug"
-var BaseUrl = "beta.sniptt.com"
+var Version = "dev"
+var BaseUrl = "api-dev.sniptt.com"

--- a/build/build.go
+++ b/build/build.go
@@ -16,5 +16,5 @@ limitations under the License.
 package build
 
 // Will be changed at build time via -ldflags
-var Version = "dev"
-var BaseUrl = "api-dev.sniptt.com"
+var Version = "debug"
+var BaseUrl = "api.sniptt.com"

--- a/build/build.go
+++ b/build/build.go
@@ -17,4 +17,4 @@ package build
 
 // Will be changed at build time via -ldflags
 var Version = "debug"
-var BaseUrl = "https://api.ots.sniptt.com/secrets"
+var BaseUrl = "beta.sniptt.com"

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -60,9 +60,7 @@ from the server upon retrieval therefore can only be viewed once.
 				return errors.New("expiry must be less than 7 days")
 			}
 
-			if !isValidRegion(region) {
-				return errors.New("invalid region")
-			}
+			// TODO: Add region validation
 
 			bytes, err := getInputBytes()
 			if err != nil {
@@ -84,7 +82,7 @@ from the server upon retrieval therefore can only be viewed once.
 			expiresAt := time.Unix(ots.ExpiresAt, 0)
 
 			q := ots.ViewURL.Query()
-			q.Set("ref", "cli")
+			q.Set("ref", "ots-cli")
 			q.Set("v", build.Version)
 			ots.ViewURL.RawQuery = q.Encode()
 			ots.ViewURL.Fragment = base64.URLEncoding.EncodeToString(key)
@@ -137,14 +135,4 @@ func getInputBytes() ([]byte, error) {
 
 		return []byte(bytes), nil
 	}
-}
-
-func isValidRegion(region string) bool {
-	switch region {
-	case
-		"us",
-		"eu":
-		return true
-	}
-	return false
 }

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	defaultExpiry = 24 * time.Hour
-	defaultRegion = "us-east-1"
+	defaultRegion = "us"
 )
 
 var (
@@ -58,6 +58,10 @@ from the server upon retrieval therefore can only be viewed once.
 
 			if expires.Hours() > 168 {
 				return errors.New("expiry must be less than 7 days")
+			}
+
+			if !isValidRegion(region) {
+				return errors.New("invalid region")
 			}
 
 			bytes, err := getInputBytes()
@@ -109,7 +113,7 @@ func init() {
 	rootCmd.AddCommand(newCmd)
 
 	newCmd.Flags().DurationVarP(&expires, "expires", "x", defaultExpiry, "Secret will be deleted from the server after specified duration, supported units: s,m,h")
-	newCmd.Flags().StringVar(&region, "region", defaultRegion, "The region where secret should be created, supported regions: us-east-1,eu-central-1")
+	newCmd.Flags().StringVar(&region, "region", defaultRegion, "The region where secret should be created, supported regions: us,eu")
 }
 
 func getInputBytes() ([]byte, error) {
@@ -133,4 +137,14 @@ func getInputBytes() ([]byte, error) {
 
 		return []byte(bytes), nil
 	}
+}
+
+func isValidRegion(region string) bool {
+	switch region {
+	case
+		"us",
+		"eu":
+		return true
+	}
+	return false
 }

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -33,12 +33,13 @@ import (
 
 const (
 	defaultExpiry = 24 * time.Hour
+	defaultRegion = "us-east-1"
 )
 
 var (
 	expires time.Duration
+	region  string
 
-	// newCmd represents the new command.
 	newCmd = &cobra.Command{
 		Use:   "new",
 		Short: "Create end-to-end encrypted secret",
@@ -46,7 +47,7 @@ var (
 Encrypts a secret and makes it available for sharing via one-time URL.
 
 The secret is stored encrypted for a specified duration which can range
-from 5 minutes to 7 days (default is 72 hours). The secret gets deleted
+from 5 minutes to 7 days (default is 24 hours). The secret gets deleted
 from the server upon retrieval therefore can only be viewed once.
 `,
 		Args: cobra.NoArgs,
@@ -71,7 +72,7 @@ from the server upon retrieval therefore can only be viewed once.
 
 			ciphertext, key := encryptedBytes.Ciphertext, encryptedBytes.Key
 
-			ots, err := client.CreateOts(ciphertext, expires)
+			ots, err := client.CreateOts(ciphertext, expires, region)
 			if err != nil {
 				return err
 			}
@@ -108,6 +109,7 @@ func init() {
 	rootCmd.AddCommand(newCmd)
 
 	newCmd.Flags().DurationVarP(&expires, "expires", "x", defaultExpiry, "Secret will be deleted from the server after specified duration, supported units: s,m,h")
+	newCmd.Flags().StringVar(&region, "region", defaultRegion, "The region where secret should be created, supported regions: us-east-1,eu-central-1")
 }
 
 func getInputBytes() ([]byte, error) {

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	defaultExpiry = 24 * time.Hour
-	defaultRegion = "us"
+	defaultRegion = "us-east-1"
 )
 
 var (
@@ -60,7 +60,9 @@ from the server upon retrieval therefore can only be viewed once.
 				return errors.New("expiry must be less than 7 days")
 			}
 
-			// TODO: Add region validation
+			if !isValidRegion(region) {
+				return errors.New("invalid region")
+			}
 
 			bytes, err := getInputBytes()
 			if err != nil {
@@ -83,6 +85,7 @@ from the server upon retrieval therefore can only be viewed once.
 
 			q := ots.ViewURL.Query()
 			q.Set("ref", "ots-cli")
+			q.Set("region", region)
 			q.Set("v", build.Version)
 			ots.ViewURL.RawQuery = q.Encode()
 			ots.ViewURL.Fragment = base64.URLEncoding.EncodeToString(key)
@@ -111,7 +114,7 @@ func init() {
 	rootCmd.AddCommand(newCmd)
 
 	newCmd.Flags().DurationVarP(&expires, "expires", "x", defaultExpiry, "Secret will be deleted from the server after specified duration, supported units: s,m,h")
-	newCmd.Flags().StringVar(&region, "region", defaultRegion, "The region where secret should be created, supported regions: us,eu")
+	newCmd.Flags().StringVar(&region, "region", defaultRegion, "The region where secret should be created, supported regions: us-east-1,eu-central-1")
 }
 
 func getInputBytes() ([]byte, error) {
@@ -135,4 +138,14 @@ func getInputBytes() ([]byte, error) {
 
 		return []byte(bytes), nil
 	}
+}
+
+func isValidRegion(region string) bool {
+	switch region {
+	case
+		"us-east-1",
+		"eu-central-1":
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
`ots new` now produces:

```
Your secret is now available on the below URL.

https://ots.sniptt.com/view/0U5dcqD0ivNHExLV?ref=ots-cli&region=us-east-1&v=debug#cC2PYfuJYp2yRXV_myg3FXMUlralJORIVlUNdm8_KcA=

You should only share this URL with the intended recipient.

Please note that once retrieved, the secret will no longer
be available for viewing. If not viewed, the secret will
automatically expire at approximately 18 Aug 2021 22:19:41.```